### PR TITLE
Fixed parsing of countries from nordvpn client

### DIFF
--- a/code/nordvpn_indicator.py
+++ b/code/nordvpn_indicator.py
@@ -484,10 +484,10 @@ class NordVPN(object):
         countries = self.run_command('nordvpn countries')
         if countries is None:
             return []
-        country_list = ''.join(countries).split(' ')[2].split()
+        #country_list = ''.join(countries).split(' ')[2].split()
+        country_list = [c.replace(',','') for c in ''.join(countries).split()[1:]]
         country_list.sort()
         return country_list
-        #return countries.split(' ')[2].split().sort()
 
     def get_settings(self):
         """


### PR DESCRIPTION
Apparently the list of countries was not correctly displayed in the "Connect" menu and in the Settings panel, due to a bug in parsing the output of the command "nordvpn countries". Something must have changed in the latest version of the Linux client app.
If the command is run from the command line the returned country names are separated by '\t` chars, instead when the python script run the same command with ``subprocess.Popen(...)``, the returned country names are separated by commas. I do not know the reason for that yet.
The fix in this diff works if the script is run automatically by the system but it won't work when run from the command line