### PR TITLE
Output warnings from commands are displayed in the status string

### DIFF
--- a/code/nordvpn_indicator.py
+++ b/code/nordvpn_indicator.py
@@ -376,8 +376,7 @@ def main():
     Signal for allowing Ctrl+C interrupts
     """
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    nordvpn = NordVPN()
-    Indicator(nordvpn)
+    Indicator(NordVPN())
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I recently updated the nordvpn client and when I tried to connect through the Indicator, nothing was happening. I then realised that I needed to login again, but the Indicator had no idea.
These changes should help in understand these type of problems, by setting the indicator icon to the yellow one and by adding a warning message to the status label.
Unlucky not all commands output contains the warning messages, "nordvpn status" for example will not tell that you need to login. The drawback of this is that, once the Indicator shows the warning and the user logs in the app through a terminal with his/her credentials, then the Indicator will stay "yellow" until the next command is issued (and this time succeeded)