### PR TITLE
Refactored setting window to load settings dynamically

### DIFF
--- a/code/nordvpn.py
+++ b/code/nordvpn.py
@@ -213,14 +213,14 @@ class NordVPN(object):
         """
         for key, value in settings.items():
             self._run_command('nordvpn set {} {}'.format(
-                self._format_setting_name(key), str(value).lower()))
+                format_setting_name(key), str(value).lower()))
 
     def set_setting(self, setting_name, setting_args):
         """
         Set a specifig NordVPN setting with the given arguments
         """
         command = 'nordvpn set {} {}'.format(
-                self._format_setting_name(setting_name), setting_args
+                format_setting_name(setting_name), setting_args
             )
         output = self._run_command(command)
         if output is None:
@@ -257,7 +257,7 @@ class NordVPN(object):
         Return the help message relative to the specified setting
         """
         help_command = 'nordvpn set {} --help'.format(
-            self._format_setting_name(setting_name)
+            format_setting_name(setting_name)
         )
         message = self._run_command(help_command)
         if message is None:
@@ -339,9 +339,11 @@ class NordVPN(object):
             settings[key] = value
         return settings
 
-    def _format_setting_name(self, setting_name):
-        """
-        Return the given setting name formatted for compatibility
-        for "nordvpn set" command
-        """
-        return setting_name.replace(' ', '').replace('-', '').lower()
+# Utility functions
+
+def format_setting_name(setting_name):
+    """
+    Return the given setting name formatted for compatibility
+    for "nordvpn set" command
+    """
+    return setting_name.replace(' ', '').replace('-', '').lower()

--- a/code/nordvpn_indicator.py
+++ b/code/nordvpn_indicator.py
@@ -15,7 +15,7 @@ gi.require_version('AppIndicator3', '0.1')
 from gi.repository import Gtk as gtk
 from gi.repository import AppIndicator3 as appindicator
 
-from nordvpn import NordVPN, ConnectionStatus, Settings, NordVPNStatus
+from nordvpn import NordVPN, ConnectionStatus, NordVPNStatus
 
 
 APPINDICATOR_ID = 'nordvpn_tray_icon'
@@ -219,6 +219,8 @@ class SettingsWindow(gtk.Window):
     def __init__(self, nordvpn):
         super(SettingsWindow, self).__init__()
         self.nordvpn = nordvpn
+        self.selected_setting = None
+        # GTK Window configuration
         self.set_default_size(200,200)
         self.set_title('NordVPN settings')
         self.set_border_width(8)
@@ -227,147 +229,86 @@ class SettingsWindow(gtk.Window):
         self.set_focus()
         # Build window layout
         self.add(self.create_widgets())
-        # Create empty settings dict to update only settings
-        # that change, and only if they change
-        self.settings = {}
 
     def create_widgets(self):
+        # TODO start a timer that keep updating the settings
         settings = self.nordvpn.get_settings()
+        # Store the setting widget to update its value
+        self.settings_labels = dict()
 
-        m_vbox = gtk.VBox()
+        m_vbox = gtk.VBox(False, 20)
 
-        row_protocol = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
-        row_protocol.add(gtk.Label(Settings.PROTOCOL.value))
-        combo_protocol = gtk.ComboBoxText()
-        combo_protocol.set_property('name', Settings.PROTOCOL.value)
-        combo_protocol.append('udp', 'UDP') # id and string
-        combo_protocol.append('tcp', 'TCP')
-        combo_protocol.set_active_id('tcp' if settings[Settings.PROTOCOL] else 'udp')
-        combo_protocol.connect('changed', self.on_setting_update)
-        row_protocol.add(combo_protocol)
+        # Main parent sections that holds the current settings
+        row_current = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
+        vbox_settings = gtk.VBox(False, 5)
+        vbox_settings.add(gtk.Label('Current NordVPN settings'))
+        vbox_settings.add(gtk.Label('(Hover on each setting row for a tooltip)'))
+        for key, value in settings.items():
+            # Create a row to display the current setting
+            row_setting = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
+            widget = gtk.Label('{}: {}'.format(key, value))
+            row_setting.add(widget)
+            # Store the widget in the dict to update its value later
+            self.settings_labels[key] = widget
+            # Set the help message as widget tooltip
+            row_setting.set_tooltip_text(self.nordvpn.get_help_message(key))
+            vbox_settings.add(row_setting)
+        # Add vertical box to the first window row
+        row_current.pack_start(vbox_settings, True, True, 0)
 
-        row_kill_switch = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
-        row_kill_switch.add(gtk.Label(Settings.KILL_SWITCH.value))
-        combo_kill = gtk.ComboBoxText()
-        combo_kill.set_property('name', Settings.KILL_SWITCH.value)
-        combo_kill.append('on', 'On')
-        combo_kill.append('off', 'Off')
-        combo_kill.set_active_id('on' if settings[Settings.KILL_SWITCH] else 'off')
-        combo_kill.connect('changed', self.on_setting_update)
-        row_kill_switch.add(combo_kill)
-
-        row_cybersec = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
-        row_cybersec.add(gtk.Label(Settings.CYBER_SEC.value))
-        combo_cybersec = gtk.ComboBoxText()
-        combo_cybersec.set_property('name', Settings.CYBER_SEC.value)
-        combo_cybersec.append('on', 'On')
-        combo_cybersec.append('off', 'Off')
-        combo_cybersec.set_active_id('on' if settings[Settings.CYBER_SEC] else 'off')
-        combo_cybersec.connect('changed', self.on_setting_update)
-        row_cybersec.add(combo_cybersec)
-
-        row_obfuscate = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
-        row_obfuscate.add(gtk.Label(Settings.OBFUSCATE.value))
-        combo_obfuscate = gtk.ComboBoxText()
-        combo_obfuscate.set_property('name', Settings.OBFUSCATE.value)
-        combo_obfuscate.append('on', 'On')
-        combo_obfuscate.append('off', 'Off')
-        combo_obfuscate.set_active_id('on' if settings[Settings.OBFUSCATE] else 'off')
-        combo_obfuscate.connect('changed', self.on_setting_update)
-        row_obfuscate.add(combo_obfuscate)
-
-        row_notify = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
-        row_notify.add(gtk.Label(Settings.NOTIFY.value))
-        combo_notify = gtk.ComboBoxText()
-        combo_notify.set_property('name', Settings.NOTIFY.value)
-        combo_notify.append('on', 'On')
-        combo_notify.append('off', 'Off')
-        combo_notify.set_active_id('on' if settings[Settings.NOTIFY] else 'off')
-        combo_notify.connect('changed', self.on_setting_update)
-        row_notify.add(combo_notify)
-
-        row_autoconnect = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
-        row_autoconnect.add(gtk.Label(Settings.AUTO_CONNECT.value))
-        combo_autoconnect = gtk.ComboBoxText()
-        combo_autoconnect.set_property('name', Settings.AUTO_CONNECT.value)
-        combo_autoconnect.append('off', 'Off')
-        combo_autoconnect.append('auto', 'Automatic')
-        for country in self.nordvpn.get_countries():
-            combo_autoconnect.append(country.lower(), country)
-        combo_autoconnect.set_active_id('auto' if settings[Settings.AUTO_CONNECT] else 'off')
-        combo_autoconnect.connect('changed', self.on_setting_update)
-        row_autoconnect.add(combo_autoconnect)
-
-        # FIXME The DNS setting widget is not used at the moment
-        row_dns = gtk.Box(gtk.Orientation.HORIZONTAL, 4, halign=gtk.Align.FILL)
-        check_dns = gtk.CheckButton(Settings.DNS.value)
-        row_dns.add(check_dns)
-        dns_vbox = gtk.VBox(valign=gtk.Align.END)
-        entry_dns_one = gtk.Entry()
-        entry_dns_one.set_placeholder_text('IP address...')
-        dns_vbox.add(entry_dns_one)
-        entry_dns_two = gtk.Entry()
-        entry_dns_two.set_placeholder_text('IP address...')
-        dns_vbox.add(entry_dns_two)
-        entry_dns_three = gtk.Entry()
-        entry_dns_three.set_placeholder_text('IP address...')
-        dns_vbox.add(entry_dns_three)
-        dns_vbox.set_sensitive(False)
-        row_dns.add(dns_vbox)
-
-        row_blank = gtk.Box(gtk.Orientation.HORIZONTAL, 4, halign=gtk.Align.END)
-        row_blank.add(gtk.Label())
-
-        row_buttons = gtk.Box(gtk.Orientation.HORIZONTAL, 4, halign=gtk.Align.END)
+        # Section containing widgets to change current settings
+        row_set = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
+        row_set.add(gtk.Label('nordvpn set '))
+        # Combo box to select setting to update
+        combo_set = gtk.ComboBoxText()
+        for key, value in settings.items():
+            combo_set.append(key, key)
+        combo_set.connect('changed', self.on_setting_selection)
+        combo_set.set_active_id(settings.items()[0][0])
+        row_set.add(combo_set)
+        # Entry to insert setting command
+        self.entry_set = gtk.Entry()
+        row_set.add(self.entry_set)
+        # Apply button to set the entered command
         button_apply = gtk.Button('Apply')
         button_apply.connect('clicked', self.on_apply)
+        row_set.add(button_apply)
+
+        # Display command output in this section
+        row_output = gtk.Box(gtk.Orientation.HORIZONTAL, 4)
+        vbox_output = gtk.VBox(False, 5)
+        vbox_output.pack_start(gtk.Label('Output: '), True, False, 0)
+        self.cmd_output = gtk.Label('')
+        vbox_output.pack_start(self.cmd_output, True, False, 0)
+        row_output.pack_start(vbox_output, True, False, 0)
+
+        row_buttons = gtk.Box(gtk.Orientation.HORIZONTAL, 4, halign=gtk.Align.END)
         button_close = gtk.Button('Close')
         button_close.connect('clicked', self.on_close)
         row_buttons.add(button_close)
-        row_buttons.add(button_apply)
 
-        m_vbox.pack_start(row_protocol, True, False, 0)
-        m_vbox.pack_start(row_kill_switch, True, False, 0)
-        m_vbox.pack_start(row_cybersec, True, False, 0)
-        m_vbox.pack_start(row_obfuscate, True, False, 0)
-        m_vbox.pack_start(row_notify, True, False, 0)
-        m_vbox.pack_start(row_autoconnect, True, False, 0)
-        m_vbox.pack_start(row_dns, True, False, 0)
-        m_vbox.pack_start(row_blank, True, False, 0)
+        m_vbox.pack_start(row_current, True, True, 0)
+        m_vbox.pack_start(gtk.HSeparator(), True, False, 0)
+        m_vbox.pack_start(row_set, True, False, 0)
+        m_vbox.pack_start(row_output, True, False, 0)
         m_vbox.pack_start(row_buttons, True, False, 0)
         return m_vbox
 
     def on_close(self, widget):
-        """
-        Close the settings window
-        """
         self.destroy()
 
-    def on_apply(self, widget):
-        """
-        Save the selected settings and pass them through the result callback
-        """
-        # Call the function to actually set the settings
-        self.nordvpn.set_settings(self.settings)
-        # Reset internal member to avoid set again the same settings
-        self.settings = {}
+    def on_setting_selection(self, widget):
+        self.selected_setting = widget.get_active_text()
 
-    def on_setting_update(self, widget):
-        """
-        Callback to handle a selection from the settings widgets
-        """
-        if widget.get_name() == Settings.PROTOCOL.value:
-            self.settings[Settings.PROTOCOL] = widget.get_active_text()
-        elif widget.get_name() == Settings.KILL_SWITCH.value:
-            self.settings[Settings.KILL_SWITCH] = (widget.get_active_text().lower() == 'on')
-        elif widget.get_name() == Settings.CYBER_SEC.value:
-            self.settings[Settings.CYBER_SEC] = (widget.get_active_text().lower() == 'on')
-        elif widget.get_name() == Settings.OBFUSCATE.value:
-            self.settings[Settings.OBFUSCATE] = (widget.get_active_text().lower() == 'on')
-        elif widget.get_name() == Settings.AUTO_CONNECT.value:
-            self.settings[Settings.AUTO_CONNECT] = widget.get_active_text().replace(' ','_')
-        elif widget.get_name() == Settings.NOTIFY.value:
-            self.settings[Settings.NOTIFY] = (widget.get_active_text().lower() == 'on')
+    def on_apply(self, widget):
+        output = self.nordvpn.set_setting(self.selected_setting, self.entry_set.get_text())
+        # Show output in window
+        self.cmd_output.set_text(output)
+        # Clear the Entry widget
+        self.entry_set.set_text('')
+        # Update the current settings labels
+        for key, value in self.nordvpn.get_settings().items():
+            self.settings_labels[key].set_text('{}: {}'.format(key, value))
 
 def main():
     """


### PR DESCRIPTION
This PR is to close Issue #2 

I have completely changed the Settings window:
- There is a section that shows the current settings values
- There are tooltips that provide help in how to change each setting with the correct values
- There is a section to set/change a setting parameter to a new value
- There is a section that shows the output of the "change" command

I think the look is much cleaner and now it is actually usable as an alternative than the command line.
The big win is that we are not dependant on the NordVPN settings values, they can add or remove settings and the window will automatically support the changes.

If this is approved I think that PR #13 can be rejected as not necessary