### PR TITLE
Make install.sh and uninstall.sh idempotent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,10 +65,11 @@ install_indicator
 # Starting script
 if pgrep -f "nordvpn_indicator" > /dev/null
 then
-    echo "Indicator already running"
-else
-    echo "Starting indicator"
-    nohup $(command -v python) /opt/ubuntu-nordvpn-indicator/nordvpn_indicator.py >/dev/null 2>&1 &
+    echo "Killing indicator"
+    kill $(pgrep -f "nordvpn_indicator")
 fi
+
+echo "Starting indicator"
+nohup $(command -v python) /opt/ubuntu-nordvpn-indicator/nordvpn_indicator.py >/dev/null 2>&1 &
 
 echo "Finished"

--- a/install.sh
+++ b/install.sh
@@ -1,59 +1,74 @@
-#!/bin/sh
+#!/bin/bash
 
 install_client()
 {
     # Get NordVPN Repo Setup (https://nordvpn.com/download/linux/)
-    echo Getting the NordVPN Repo Setup
+    echo "Getting the NordVPN Repo Setup"
     wget https://repo.nordvpn.com/deb/nordvpn/debian/pool/main/nordvpn-release_1.0.0_all.deb
 
     # Install downloaded package
-    echo Installing the NordVPN Repo Setup
+    echo "Installing the NordVPN Repo Setup"
     sudo apt-get install -y nordvpn-release_1.0.0_all.deb
     rm nordvpn-release_1.0.0_all.deb
 
     # Update packages
-    echo Updating packages
+    echo "Updating packages"
     sudo apt-get update
 
     # Install NordVPN
-    echo Installing NordVPN
+    echo "Installing NordVPN"
     sudo apt-get install -y nordvpn
 
     # Prompting user to login
-    echo Logging into NordVPN
+    echo "Logging into NordVPN"
     nordvpn login
 }
 
 install_deps()
 {
     # Install gir1.2-appindicator
-    echo Installing AppIndicator
+    echo "Installing AppIndicator and Python-GI"
     sudo apt-get install -y gir1.2-appindicator python-gi
 }
 
 install_indicator()
 {
     # Installing indicator in opt directory
-    echo Installing Ubuntu NordVPN Indicator
+    echo "Installing Ubuntu NordVPN Indicator"
     sudo mkdir -p /opt/ubuntu-nordvpn-indicator/
     sudo cp code/* /opt/ubuntu-nordvpn-indicator/
 
     # Installing autostart desktop file
-    echo Making sure the indicator starts at boot using autostart
+    echo "Making sure the indicator starts at boot using autostart"
     mkdir -p $HOME/.config/autostart
     cp ubuntu-nordvpn-indicator.desktop $HOME/.config/autostart/
 }
 
+# Install client if not present
 if ! command -v nordvpn > /dev/null 2>&1;
 then
     install_client
 fi
 
-install_deps
+# Install dependencies if not present
+deps_available=$(dpkg -l | grep -E "gir1.2-appindicator-|python-gi"  | wc --lines)
+if [[ $deps_available -eq 2 ]]
+then
+    echo "Dependencies have been installed"
+else
+    install_deps
+fi
+
+# Install indicator
 install_indicator
 
 # Starting script
-echo Starting indicator
-nohup $(command -v python) /opt/ubuntu-nordvpn-indicator/nordvpn_indicator.py >/dev/null 2>&1 &
+if pgrep -f "nordvpn_indicator" > /dev/null
+then
+    echo "Indicator already running"
+else
+    echo "Starting indicator"
+    nohup $(command -v python) /opt/ubuntu-nordvpn-indicator/nordvpn_indicator.py >/dev/null 2>&1 &
+fi
 
-echo Finished
+echo "Finished"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,16 +1,33 @@
 #!/bin/bash
 
-echo Removing Ubuntu NordVPN Indicator
+echo "Removing Ubuntu NordVPN Indicator"
 rm ~/.config/autostart/ubuntu-nordvpn-indicator.desktop
 sudo rm -rf /opt/ubuntu-nordvpn-indicator
+
+read -p "Do you want to uninstall AppIndicator? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Uninstalling AppIndicator"
+    sudo apt-get remove -y gir1.2-appindicator
+fi
+
+read -p "Do you want to uninstall Python-GI? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Uninstalling Python-GI"
+    sudo apt-get remove -y python-gi
+fi
+
 
 read -p "Do you want to uninstall NordVPN? " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    echo Disconnecting NordVPN
+    echo "Disconnecting NordVPN"
     nordvpn disconnect
 
-    echo Uninstalling NordVPN
+    echo "Uninstalling NordVPN"
     sudo apt-get remove -y nordvpn
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,7 +4,7 @@ echo "Removing Ubuntu NordVPN Indicator"
 rm ~/.config/autostart/ubuntu-nordvpn-indicator.desktop
 sudo rm -rf /opt/ubuntu-nordvpn-indicator
 
-read -p "Do you want to uninstall AppIndicator? " -n 1 -r
+read -p "Do you want to uninstall AppIndicator? [Y/n]" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
@@ -12,7 +12,7 @@ then
     sudo apt-get remove -y gir1.2-appindicator
 fi
 
-read -p "Do you want to uninstall Python-GI? " -n 1 -r
+read -p "Do you want to uninstall Python-GI? [Y/n]" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
@@ -21,7 +21,7 @@ then
 fi
 
 
-read -p "Do you want to uninstall NordVPN? " -n 1 -r
+read -p "Do you want to uninstall NordVPN? [Y/n]" -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then


### PR DESCRIPTION
Fixes #12 

What I did:
- Make `install.sh` idempotent. This makes script idempotent, and thus more easily automate-able using software like Chef, Puppet, or Ansible
-  Encapsulate echo contents with quotes. This improves code readability in editors like nano
- Install.sh only installs dependencies when they are not present
- Uninstall.sh offers to remove dependencies